### PR TITLE
Allow extension to run on Devin wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The conversion to Markdown format is as follows:
 
 ## Features
 
-1. Convert single page content from DeepWiki website to Markdown format
+1. Convert single page content from DeepWiki or Devin wiki pages to Markdown format
 2. One-click batch conversion and download of all subpages of a document (packaged as a ZIP file)
 3. The UML diagrams in the document will also be saved.
 
@@ -27,13 +27,13 @@ The conversion to Markdown format is as follows:
 ![](./images/UI.png)
 
 1. Single Page Conversion:
-   - Open any page on DeepWiki, such as：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
+   - Open any page on DeepWiki or Devin wiki, such as：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
    - Click the extension icon
    - Click the "Convert & Download Current Page" button
    - The page will be converted and a download dialog will appear
 
 2. Batch Download All Pages:
-   - Open a DeepWiki page, such as：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
+   - Open a DeepWiki or Devin wiki page, such as：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
    - Click the extension icon
    - Click the "Batch Convert & Download All Pages" button
    - The extension will automatically convert all page content and package them into a ZIP file for download

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 
 ## 功能特点
 
-1. 将 DeepWiki 网站的单页内容转换为 Markdown 格式
+1. 将 DeepWiki 或 Devin wiki 页面内容转换为 Markdown 格式
 2. 一键批量转换和下载文档的所有子页面（打包为 ZIP 文件）
 3. 会保存文档中的 UML 图
 
@@ -25,13 +25,13 @@
 ![](./images/UI.png)
 
 1. 单页转换：
-   - 打开任意 DeepWiki 页面，例如：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
+   - 打开任意 DeepWiki 或 Devin wiki 页面，例如：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
    - 点击扩展图标
    - 点击"Convert & Download Current Page"按钮
    - 页面将被转换，并弹出下载对话框
 
 2. 批量下载所有页面：
-   - 打开任意 DeepWiki 页面，例如：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
+   - 打开任意 DeepWiki 或 Devin wiki 页面，例如：[ThinkInAIXYZ/go-mcp](https://deepwiki.com/ThinkInAIXYZ/go-mcp)
    - 点击扩展图标
    - 点击"Batch Convert & Download All Pages"按钮
    - 扩展将自动转换所有页面内容并打包成 ZIP 文件供下载

--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+import { isSupportedWikiUrl } from './utils/urlUtils.js';
+
 // A queue to hold messages for tabs that are not yet ready
 const messageQueue = {};
 
@@ -55,7 +57,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 // Listen for tab update complete event, for batch processing
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'complete' && tab.url && tab.url.includes('deepwiki.com')) {
+  if (changeInfo.status === 'complete' && isSupportedWikiUrl(tab?.url)) {
     // Initialize the message queue for this tab as not ready
     if (!messageQueue[tabId] || !messageQueue[tabId].isReady) {
         messageQueue[tabId] = { isReady: false, queue: [] };
@@ -71,9 +73,9 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 
 // Also listen for tab activation to reinitialize connection if needed
 chrome.tabs.onActivated.addListener(activeInfo => {
-  // When a tab becomes active, check if it's a DeepWiki tab
+  // When a tab becomes active, check if it's a supported wiki tab
   chrome.tabs.get(activeInfo.tabId, tab => {
-    if (tab && tab.url && tab.url.includes('deepwiki.com')) {
+    if (tab && isSupportedWikiUrl(tab.url)) {
       // Ensure queue is initialized
       if (!messageQueue[tab.id]) {
         messageQueue[tab.id] = { isReady: false, queue: [] };

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "tabs"
   ],
   "host_permissions": [
-    "https://deepwiki.com/*"
+    "https://deepwiki.com/*",
+    "https://app.devin.ai/wiki/*"
   ],
   "action": {
     "default_popup": "popup.html",
@@ -21,7 +22,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://deepwiki.com/*"],
+      "matches": [
+        "https://deepwiki.com/*",
+        "https://app.devin.ai/wiki/*"
+      ],
       "js": ["content.js"],
       "run_at": "document_end"
     }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "deepwiki-md-chrome-extension-na",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node test/run-tests.js"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -26,6 +26,6 @@
     </div>
     <div id="status"></div>
   </div>
-  <script src="popup.js"></script>
+  <script type="module" src="popup.js"></script>
 </body>
 </html> 

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,5 @@
+import { isSupportedWikiUrl } from './utils/urlUtils.js';
+
 const FALLBACK_FILENAME = 'deepwiki-page';
 
 function sanitizeFilename(input, options = {}) {
@@ -45,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       
-      if (!tab.url.includes('deepwiki.com')) {
+      if (!isSupportedWikiUrl(tab?.url)) {
         showStatus('Please use this extension on a DeepWiki page', 'error');
         return;
       }
@@ -93,7 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       
-      if (!tab.url.includes('deepwiki.com')) {
+      if (!isSupportedWikiUrl(tab?.url)) {
         showStatus('Please use this extension on a DeepWiki page', 'error');
         return;
       }

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { isSupportedWikiUrl } from '../utils/urlUtils.js';
+
+function runTests() {
+  assert.equal(isSupportedWikiUrl('https://deepwiki.com/Some/Page'), true, 'DeepWiki path should be supported');
+  assert.equal(isSupportedWikiUrl('https://www.deepwiki.com/Another/Page'), true, 'www.DeepWiki path should be supported');
+  assert.equal(isSupportedWikiUrl('https://deepwiki.com'), true, 'DeepWiki root should be supported');
+  assert.equal(isSupportedWikiUrl('https://app.devin.ai/wiki/my-report'), true, 'Devin wiki nested path should be supported');
+  assert.equal(isSupportedWikiUrl('https://app.devin.ai/wiki'), true, 'Devin wiki root path should be supported');
+
+  assert.equal(isSupportedWikiUrl('https://app.devin.ai/other'), false, 'Devin host outside /wiki should be rejected');
+  assert.equal(isSupportedWikiUrl('https://example.com/'), false, 'Unknown host should be rejected');
+  assert.equal(isSupportedWikiUrl('not a url'), false, 'Invalid URLs should be rejected');
+  assert.equal(isSupportedWikiUrl(null), false, 'Null should be rejected');
+
+  console.log('All tests passed');
+}
+
+runTests();

--- a/utils/urlUtils.js
+++ b/utils/urlUtils.js
@@ -1,0 +1,40 @@
+const SUPPORTED_WIKI_HOSTS = new Map([
+  ['deepwiki.com', null],
+  ['www.deepwiki.com', null],
+  ['app.devin.ai', '/wiki']
+]);
+
+/**
+ * Determines whether the provided URL belongs to a supported wiki instance.
+ *
+ * @param {string|undefined|null} url - The URL to validate.
+ * @returns {boolean} True when the URL is a supported wiki page.
+ */
+export function isSupportedWikiUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) {
+    return false;
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    return false;
+  }
+
+  const requiredPathPrefix = SUPPORTED_WIKI_HOSTS.get(parsedUrl.hostname);
+  if (requiredPathPrefix === undefined) {
+    return false;
+  }
+
+  if (requiredPathPrefix === null) {
+    return true;
+  }
+
+  return (
+    parsedUrl.pathname === requiredPathPrefix ||
+    parsedUrl.pathname.startsWith(`${requiredPathPrefix}/`)
+  );
+}
+
+export { SUPPORTED_WIKI_HOSTS };


### PR DESCRIPTION
## Summary
- allow the extension background worker and popup to recognise Devin wiki URLs via a shared helper
- extend manifest host permissions/content script matches and update documentation to reflect the wider support
- add a simple Node-based test to ensure URL validation covers both DeepWiki and Devin wiki pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddcf3a2bcc83249bb1c8f47d90457f