### PR TITLE
Ensure Devin wiki root is covered by extension

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   ],
   "host_permissions": [
     "https://deepwiki.com/*",
-    "https://app.devin.ai/wiki/*"
+    "https://app.devin.ai/wiki*"
   ],
   "action": {
     "default_popup": "popup.html",
@@ -24,7 +24,7 @@
     {
       "matches": [
         "https://deepwiki.com/*",
-        "https://app.devin.ai/wiki/*"
+        "https://app.devin.ai/wiki*"
       ],
       "js": ["content.js"],
       "run_at": "document_end"

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,7 +1,30 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { isSupportedWikiUrl } from '../utils/urlUtils.js';
 
+function loadManifest() {
+  const manifestPath = new URL('../manifest.json', import.meta.url);
+  const manifestContents = readFileSync(manifestPath, 'utf-8');
+  return JSON.parse(manifestContents);
+}
+
 function runTests() {
+  const manifest = loadManifest();
+  const hostPermissions = manifest.host_permissions ?? [];
+  const contentMatches = manifest.content_scripts?.[0]?.matches ?? [];
+
+  assert.equal(
+    hostPermissions.some((permission) => permission === 'https://app.devin.ai/wiki' || permission === 'https://app.devin.ai/wiki*'),
+    true,
+    'Manifest host permissions must include Devin wiki root'
+  );
+
+  assert.equal(
+    contentMatches.some((match) => match === 'https://app.devin.ai/wiki' || match === 'https://app.devin.ai/wiki*'),
+    true,
+    'Manifest content script matches must include Devin wiki root'
+  );
+
   assert.equal(isSupportedWikiUrl('https://deepwiki.com/Some/Page'), true, 'DeepWiki path should be supported');
   assert.equal(isSupportedWikiUrl('https://www.deepwiki.com/Another/Page'), true, 'www.DeepWiki path should be supported');
   assert.equal(isSupportedWikiUrl('https://deepwiki.com'), true, 'DeepWiki root should be supported');


### PR DESCRIPTION
## Summary
- extend the extension host permissions and content script matches to cover https://app.devin.ai/wiki via a wildcard entry
- add regression tests that assert the manifest includes the Devin wiki root alongside existing URL validation tests

## Testing
- node test/run-tests.js

------
https://chatgpt.com/codex/tasks/task_e_68ddd129d2c8832495d3d37c8b7e7b3a