### PR TITLE
Improve batch page extraction for downloads

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -38,7 +38,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let currentTitle = '';
   let currentHeadTitle = '';
   let allPages = [];
-  let baseUrl = '';
   let convertedPages = []; // Store all converted page content
   let isCancelled = false; // Flag to control cancellation
 
@@ -112,7 +111,6 @@ document.addEventListener('DOMContentLoaded', () => {
       
       if (response && response.success) {
         allPages = response.pages;
-        baseUrl = response.baseUrl;
         
         // Use head title for folder name if available
         const headTitle = sanitizeFilename(response.headTitle, { allowEmpty: true });


### PR DESCRIPTION
## Summary
- broaden the selectors used to gather DeepWiki sidebar links during batch conversion
- ensure the current page is included when no sidebar links are detected and deduplicate entries
- remove unused base URL plumbing in the popup now that it is no longer provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd3c860108324b75920c2a653bfc6