### PR TITLE
Improve batch download reliability by waiting for page readiness

### DIFF
--- a/content.js
+++ b/content.js
@@ -194,6 +194,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     console.log("Tab activated:", window.location.href);
     // Acknowledge receipt of message to avoid connection errors
     sendResponse({ received: true });
+  } else if (request.action === "ping") {
+    sendResponse({ ready: true });
   }
   // Always return true for asynchronous sendResponse handling
   return true;


### PR DESCRIPTION
## Summary
- add a ping handler in the content script so the popup can verify when the page is ready
- wait for tab navigation and content script initialization before converting each page in a batch
- improve batch processing error handling and always return to the original page after finishing or cancellation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd59e4360832482a909a01acc3c38