### PR TITLE
Expand wiki link harvesting and dedupe batch filenames

### DIFF
--- a/content.js
+++ b/content.js
@@ -74,14 +74,30 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const headTitle = document.title || "";
       const formattedHeadTitle = headTitle ? sanitizeFilename(headTitle) : "";
 
-      const collectSidebarLinks = () => {
-        const selectors = [
+      const collectWikiLinks = () => {
+        const navSelectors = [
           '.border-r-border ul li a',
           'aside a[href]',
           'nav a[href]',
           '.container > div:first-child a[href]'
         ];
 
+        const contentSelectors = [
+          '.container > div:nth-child(2) .prose a[href]',
+          '.container > div:nth-child(2) .prose-custom a[href]',
+          '.container > div:nth-child(2) a[href]',
+          'main a[href]'
+        ];
+
+        const normalizePath = path => {
+          if (!path) {
+            return '/';
+          }
+
+          return path.replace(/\/+$/, '').replace(/\/+/g, '/');
+        };
+
+        const results = [];
         const seen = new Map();
 
         const isLikelyWikiPath = url => {
@@ -98,47 +114,119 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           );
         };
 
-        selectors.forEach(selector => {
-          document.querySelectorAll(selector).forEach(link => {
-            const href = link.getAttribute('href');
-            if (!href) {
-              return;
+        const isCurrentPageUrl = url => {
+          const currentUrl = new URL(window.location.href);
+          return (
+            url.origin === currentUrl.origin &&
+            normalizePath(url.pathname) === normalizePath(currentUrl.pathname) &&
+            url.search === currentUrl.search
+          );
+        };
+
+        const deriveTitleFromUrl = url => {
+          if (url.hash) {
+            const hashTitle = decodeURIComponent(url.hash.replace(/^#/, '').replace(/[-_]+/g, ' ')).trim();
+            if (hashTitle) {
+              return hashTitle;
+            }
+          }
+
+          const segments = url.pathname.split('/').filter(Boolean);
+          const lastSegment = segments[segments.length - 1] || '';
+          const decodedSegment = decodeURIComponent(lastSegment.replace(/[-_]+/g, ' ')).trim();
+
+          if (decodedSegment) {
+            return decodedSegment;
+          }
+
+          return url.href;
+        };
+
+        const getLinkTitle = link => {
+          const text = (link.textContent || '').trim();
+          if (text) {
+            return text;
+          }
+
+          const ariaLabel = link.getAttribute('aria-label');
+          if (ariaLabel && ariaLabel.trim()) {
+            return ariaLabel.trim();
+          }
+
+          const titleAttr = link.getAttribute('title');
+          if (titleAttr && titleAttr.trim()) {
+            return titleAttr.trim();
+          }
+
+          return '';
+        };
+
+        const recordLink = (link, { treatAsNav } = {}) => {
+          const href = link.getAttribute('href');
+          if (!href || href.startsWith('javascript:')) {
+            return;
+          }
+
+          let url;
+          try {
+            url = new URL(href, window.location.href);
+          } catch (err) {
+            return;
+          }
+
+          if (url.origin !== window.location.origin) {
+            return;
+          }
+
+          if (!isLikelyWikiPath(url)) {
+            return;
+          }
+
+          const key = url.href;
+          const linkTitle = getLinkTitle(link);
+          const fallbackTitle = deriveTitleFromUrl(url);
+          const isCurrent = isCurrentPageUrl(url);
+          const matchesCurrentHash = (url.hash || '') === (window.location.hash || '');
+          const selected = markSelected(link) || (isCurrent && matchesCurrentHash);
+
+          if (!seen.has(key)) {
+            const entry = {
+              url: key,
+              title: linkTitle || fallbackTitle,
+              selected: treatAsNav ? selected : (isCurrent && matchesCurrentHash),
+              fallbackTitle
+            };
+
+            seen.set(key, entry);
+            results.push(entry);
+          } else {
+            const existing = seen.get(key);
+
+            const shouldSelect = treatAsNav ? selected : (isCurrent && matchesCurrentHash);
+
+            if (!existing.selected && shouldSelect) {
+              existing.selected = true;
             }
 
-            let url;
-            try {
-              url = new URL(href, window.location.href);
-            } catch (err) {
-              return;
+            if (linkTitle && existing.title === existing.fallbackTitle) {
+              existing.title = linkTitle;
             }
+          }
+        };
 
-            if (url.origin !== window.location.origin) {
-              return;
-            }
-
-            if (!isLikelyWikiPath(url)) {
-              return;
-            }
-
-            const key = url.href;
-
-            if (!seen.has(key)) {
-              seen.set(key, {
-                url: key,
-                title: (link.textContent || '').trim() || url.pathname,
-                selected: markSelected(link)
-              });
-            } else if (!seen.get(key).selected) {
-              seen.get(key).selected = markSelected(link);
-            }
-          });
+        navSelectors.forEach(selector => {
+          document.querySelectorAll(selector).forEach(link => recordLink(link, { treatAsNav: true }));
         });
 
-        return Array.from(seen.values());
+        contentSelectors.forEach(selector => {
+          document.querySelectorAll(selector).forEach(link => recordLink(link, { treatAsNav: false }));
+        });
+
+        return results.map(({ fallbackTitle, ...rest }) => rest);
       };
 
-      // Get all links in the sidebar
-      let pages = collectSidebarLinks();
+      // Get all wiki links available on the page
+      let pages = collectWikiLinks();
 
       // Get current page information for return
       const currentPageTitle =
@@ -194,6 +282,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     console.log("Tab activated:", window.location.href);
     // Acknowledge receipt of message to avoid connection errors
     sendResponse({ received: true });
+  } else if (request.action === "ping") {
+    sendResponse({ ready: true });
   }
   // Always return true for asynchronous sendResponse handling
   return true;

--- a/popup.js
+++ b/popup.js
@@ -29,6 +29,95 @@ function sanitizeFilename(input, options = {}) {
   return sanitized;
 }
 
+const PAGE_READY_TIMEOUT_MS = 20000;
+const PAGE_READY_POLL_INTERVAL_MS = 300;
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeUrlForComparison(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    return '';
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    let normalizedPath = url.pathname;
+    if (normalizedPath.length > 1) {
+      normalizedPath = normalizedPath.replace(/\/+/g, '/');
+      normalizedPath = normalizedPath.replace(/\/+$/, '');
+    }
+
+    return `${url.origin}${normalizedPath}${url.search}${url.hash}`;
+  } catch (error) {
+    return rawUrl;
+  }
+}
+
+function urlsReferToSameDocument(firstUrl, secondUrl) {
+  return normalizeUrlForComparison(firstUrl) === normalizeUrlForComparison(secondUrl);
+}
+
+async function waitForPageInteractive(tabId, targetUrl) {
+  const normalizedTarget = normalizeUrlForComparison(targetUrl);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < PAGE_READY_TIMEOUT_MS) {
+    let tab;
+    try {
+      tab = await chrome.tabs.get(tabId);
+    } catch (error) {
+      if (error && error.message && error.message.includes('No tab with id')) {
+        throw error;
+      }
+      await delay(PAGE_READY_POLL_INTERVAL_MS);
+      continue;
+    }
+
+    const currentUrl = tab.url || tab.pendingUrl || '';
+    const normalizedCurrent = normalizeUrlForComparison(currentUrl);
+
+    if (normalizedCurrent === normalizedTarget) {
+      try {
+        const response = await chrome.tabs.sendMessage(tabId, { action: 'ping' });
+        if (response && response.ready) {
+          return tab;
+        }
+      } catch (error) {
+        // Ignore errors while waiting for the content script to initialize
+      }
+    }
+
+    await delay(PAGE_READY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timed out waiting for page readiness: ${targetUrl}`);
+}
+
+async function ensureTabAtUrl(tabId, targetUrl, previousUrl) {
+  if (!urlsReferToSameDocument(previousUrl, targetUrl)) {
+    await chrome.tabs.update(tabId, { url: targetUrl });
+  }
+
+  return waitForPageInteractive(tabId, targetUrl);
+}
+
+async function safelyReturnToUrl(tabId, targetUrl) {
+  if (!targetUrl) {
+    return null;
+  }
+
+  try {
+    const currentTab = await chrome.tabs.get(tabId);
+    const currentUrl = currentTab.url || currentTab.pendingUrl || '';
+    return await ensureTabAtUrl(tabId, targetUrl, currentUrl);
+  } catch (error) {
+    console.error('Failed to return to original page', error);
+    return null;
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const convertBtn = document.getElementById('convertBtn');
   const batchDownloadBtn = document.getElementById('batchDownloadBtn');
@@ -153,52 +242,84 @@ document.addEventListener('DOMContentLoaded', () => {
   async function processAllPages(tabId, folderName) {
     let processedCount = 0;
     let errorCount = 0;
-    
+    const usedFileTitles = new Set();
+
+    const ensureUniqueFileTitle = (baseTitle, index) => {
+      let candidate = sanitizeFilename(baseTitle || `page-${index}`);
+      if (!candidate) {
+        candidate = `page-${index}`;
+      }
+
+      if (!usedFileTitles.has(candidate)) {
+        usedFileTitles.add(candidate);
+        return candidate;
+      }
+
+      let suffix = 2;
+      let uniqueCandidate = `${candidate}-${suffix}`;
+      while (usedFileTitles.has(uniqueCandidate)) {
+        suffix += 1;
+        uniqueCandidate = `${candidate}-${suffix}`;
+      }
+
+      usedFileTitles.add(uniqueCandidate);
+      return uniqueCandidate;
+    };
+
     // Save current page URL
     const currentPageUrl = allPages.find(page => page.selected)?.url || "";
-    
+    let lastVisitedUrl = currentPageUrl;
+
+    try {
+      const activeTab = await chrome.tabs.get(tabId);
+      lastVisitedUrl = activeTab.url || activeTab.pendingUrl || currentPageUrl;
+    } catch (error) {
+      lastVisitedUrl = currentPageUrl;
+    }
+
     for (const page of allPages) {
       // Check if operation was cancelled
       if (isCancelled) {
         showStatus(`Operation cancelled. Processed: ${processedCount}, Failed: ${errorCount}`, 'info');
         // Return to original page
-        if (currentPageUrl) {
-          await chrome.tabs.update(tabId, { url: currentPageUrl });
-        }
+        await safelyReturnToUrl(tabId, currentPageUrl);
         return;
       }
 
       try {
         showStatus(`Processing ${processedCount + 1}/${allPages.length}: ${page.title}`, 'info');
-        
-        // Navigate to page
-        await chrome.tabs.update(tabId, { url: page.url });
-        
-        // Wait for page to load
-        await new Promise(resolve => setTimeout(resolve, 2000)); // Increase waiting time to ensure page loads
-        
-        // Check again if cancelled during wait
+
+        // Ensure the tab has navigated and the content script is ready
+        const readyTab = await ensureTabAtUrl(tabId, page.url, lastVisitedUrl);
+        lastVisitedUrl = readyTab?.url || readyTab?.pendingUrl || page.url;
+
+        // Check again if cancelled after navigation
         if (isCancelled) {
           showStatus(`Operation cancelled. Processed: ${processedCount}, Failed: ${errorCount}`, 'info');
-          if (currentPageUrl) {
-            await chrome.tabs.update(tabId, { url: currentPageUrl });
-          }
+          await safelyReturnToUrl(tabId, currentPageUrl);
           return;
         }
-        
+
         // Convert page content
         const convertResponse = await chrome.tabs.sendMessage(tabId, { action: 'convertToMarkdown' });
         
         if (convertResponse && convertResponse.success) {
+          const displayTitle = page.title || convertResponse.markdownTitle || `Page ${processedCount + 1}`;
+          const preferredFileTitle =
+            page.title && page.title.trim()
+              ? page.title
+              : convertResponse.markdownTitle || convertResponse.currentTitle || displayTitle;
+
+          const fileTitle = ensureUniqueFileTitle(preferredFileTitle, processedCount + 1);
+
           // Store converted content
           convertedPages.push({
-            displayTitle: page.title,
-            fileTitle: sanitizeFilename(
-              convertResponse.markdownTitle || page.title
-            ),
-            content: convertResponse.markdown
+            displayTitle,
+            fileTitle,
+            content: convertResponse.markdown,
+            sourceUrl: page.url
           });
-          
+
           processedCount++;
         } else {
           errorCount++;
@@ -207,14 +328,20 @@ document.addEventListener('DOMContentLoaded', () => {
       } catch (err) {
         errorCount++;
         console.error(`Error processing page: ${page.title}`, err);
+        showStatus(`Failed to process ${page.title}. Continuing...`, 'error');
+
+        try {
+          const fallbackTab = await chrome.tabs.get(tabId);
+          lastVisitedUrl = fallbackTab.url || fallbackTab.pendingUrl || lastVisitedUrl;
+        } catch (fallbackError) {
+          // Ignore - we'll rely on the last known URL
+        }
       }
     }
-    
+
     // Return to original page after processing
-    if (currentPageUrl) {
-      await chrome.tabs.update(tabId, { url: currentPageUrl });
-    }
-    
+    await safelyReturnToUrl(tabId, currentPageUrl);
+
     if (!isCancelled) {
       showStatus(`Batch conversion complete! Success: ${processedCount}, Failed: ${errorCount}, Preparing download...`, 'success');
     }


### PR DESCRIPTION
## Summary
- collect DeepWiki links from both navigation and article content areas during batch extraction
- ensure the current page is retained in the batch list and mark the active hash correctly
- deduplicate generated markdown filenames so every downloaded page gets a unique file in the zip

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd59e4360832482a909a01acc3c38