### PR TITLE
Fix batch download errors when content script missing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "activeTab",
     "downloads",
-    "tabs"
+    "tabs",
+    "scripting"
   ],
   "host_permissions": [
     "https://deepwiki.com/*",


### PR DESCRIPTION
## Summary
- add the scripting permission so the extension can programmatically inject its content script
- add helper utilities in the popup to retry sending messages after injecting the content script when no receiver is present
- use the new helper everywhere the popup talks to a tab so batch conversion no longer fails with “receiving end does not exist” errors

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691552909c488324b2ef49400130cb90)