### PR TITLE
Prevent DeepWiki batch convert from following non-wiki links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "activeTab",
     "downloads",
-    "tabs"
+    "tabs",
+    "scripting"
   ],
   "host_permissions": [
     "https://deepwiki.com/*",


### PR DESCRIPTION
## Summary
- add namespace-aware filtering and disallowed path checks when extracting DeepWiki links so batch conversion stays inside the current wiki instead of wandering to login/logout or marketing pages
- keep the original navigation ordering while discarding out-of-scope links to avoid getting logged out mid-run and ensure the batch workflow finishes and downloads

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691552909c488324b2ef49400130cb90)