### PR TITLE
Move batch conversion logic to background worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,10 +1,23 @@
+import JSZip from './utils/jszipLoader.js';
+import {
+  sanitizeFilename,
+  ensureMarkdownExtension,
+  ensureUniqueName,
+  ensureUniqueFileTitle
+} from './utils/fileNameUtils.js';
+import {
+  sendMessageToTab as sendAsyncMessageToTab,
+  ensureTabAtUrl,
+  safelyReturnToUrl
+} from './utils/tabNavigation.js';
 import { isSupportedWikiUrl } from './utils/urlUtils.js';
 
 // A queue to hold messages for tabs that are not yet ready
 const messageQueue = {};
+const batchJobs = new Map();
 
 // Function to safely send a message to a tab, queuing if necessary
-function sendMessageToTab(tabId, message) {
+function queueMessageToTab(tabId, message) {
   // Check if the content script is ready. We'll use a simple check for now.
   // A more robust way is for the content script to notify when it's ready.
   if (messageQueue[tabId] && messageQueue[tabId].isReady) {
@@ -21,6 +34,306 @@ function sendMessageToTab(tabId, message) {
     messageQueue[tabId].queue.push(message);
     console.log(`Message queued for tab ${tabId}:`, message.action);
   }
+}
+
+function createBatchJob(tabId) {
+  return {
+    tabId,
+    cancelRequested: false,
+    cancelled: false,
+    completed: false,
+    processedCount: 0,
+    errorCount: 0,
+    total: 0,
+    folderName: '',
+    allPages: [],
+    convertedPages: [],
+    lastMessage: '',
+    lastStatusType: 'info',
+    currentPageUrl: ''
+  };
+}
+
+function serializeJob(job) {
+  if (!job) {
+    return null;
+  }
+
+  return {
+    tabId: job.tabId,
+    running: !job.completed,
+    completed: job.completed,
+    cancelRequested: job.cancelRequested,
+    cancelled: job.cancelled,
+    processedCount: job.processedCount,
+    total: job.total,
+    errorCount: job.errorCount,
+    statusType: job.lastStatusType,
+    message: job.lastMessage
+  };
+}
+
+function sendBatchUpdate(job, update = {}) {
+  const payload = {
+    action: 'batchUpdate',
+    tabId: job.tabId,
+    processedCount: job.processedCount,
+    total: job.total,
+    errorCount: job.errorCount,
+    cancelRequested: job.cancelRequested,
+    cancelled: job.cancelled,
+    completed: update.completed ?? job.completed,
+    running: update.running ?? !job.completed,
+    statusType: update.statusType ?? job.lastStatusType,
+    message: update.message ?? job.lastMessage
+  };
+
+  try {
+    const result = chrome.runtime.sendMessage(payload);
+    if (result && typeof result.then === 'function') {
+      result.catch(() => {});
+    }
+  } catch (error) {
+    if (!error?.message?.includes('Receiving end does not exist')) {
+      console.warn('Failed to deliver batch update:', error);
+    }
+  }
+}
+
+function updateJobStatus(job, message, statusType = 'info', update = {}) {
+  job.lastMessage = message;
+  job.lastStatusType = statusType;
+  sendBatchUpdate(job, { message, statusType, ...update });
+}
+
+async function runBatchConversion(job) {
+  try {
+    const tab = await chrome.tabs.get(job.tabId);
+    if (!isSupportedWikiUrl(tab?.url)) {
+      throw new Error('Please use this extension on a DeepWiki page');
+    }
+
+    job.currentPageUrl = tab.url || tab.pendingUrl || '';
+
+    updateJobStatus(job, 'Extracting all page links...', 'info', { running: true });
+
+    const response = await sendAsyncMessageToTab(job.tabId, { action: 'extractAllPages' });
+
+    if (!response?.success) {
+      throw new Error(response?.error || 'Failed to extract page links');
+    }
+
+    job.allPages = Array.isArray(response.pages) ? response.pages : [];
+    job.total = job.allPages.length;
+    const headTitle = sanitizeFilename(response.headTitle, { allowEmpty: true });
+    const fallbackFolderName = sanitizeFilename(response.currentTitle || '', { allowEmpty: true });
+    job.folderName = headTitle || fallbackFolderName || 'deepwiki-export';
+
+    updateJobStatus(job, `Found ${job.total} pages, starting batch conversion`, 'info', { running: true });
+
+    await processJobPages(job);
+
+    if (job.cancelRequested) {
+      job.cancelled = true;
+      job.completed = true;
+      updateJobStatus(
+        job,
+        `Operation cancelled. Processed: ${job.processedCount}, Failed: ${job.errorCount}`,
+        'info',
+        { completed: true, running: false }
+      );
+      return;
+    }
+
+    if (job.convertedPages.length === 0) {
+      job.completed = true;
+      updateJobStatus(job, 'No pages were converted.', 'error', { completed: true, running: false });
+      return;
+    }
+
+    await downloadJobZip(job);
+
+    job.completed = true;
+    updateJobStatus(
+      job,
+      `ZIP file successfully generated! Contains ${job.convertedPages.length} Markdown files`,
+      'success',
+      { completed: true, running: false }
+    );
+  } catch (error) {
+    job.completed = true;
+    updateJobStatus(job, `Batch conversion failed: ${error.message}`, 'error', { completed: true, running: false });
+    console.error('Batch conversion error:', error);
+  } finally {
+    batchJobs.delete(job.tabId);
+  }
+}
+
+async function processJobPages(job) {
+  const usedFileTitles = new Set();
+  const currentPageUrl = job.allPages.find(page => page?.selected)?.url || job.currentPageUrl || '';
+  job.currentPageUrl = currentPageUrl;
+
+  let lastVisitedUrl = currentPageUrl;
+  try {
+    const activeTab = await chrome.tabs.get(job.tabId);
+    lastVisitedUrl = activeTab.url || activeTab.pendingUrl || currentPageUrl;
+  } catch (error) {
+    lastVisitedUrl = currentPageUrl;
+  }
+
+  for (const page of job.allPages) {
+    if (job.cancelRequested) {
+      break;
+    }
+
+    const pageTitle = page?.title || page?.url || `Page ${job.processedCount + 1}`;
+    updateJobStatus(
+      job,
+      `Processing ${job.processedCount + 1}/${job.total}: ${pageTitle}`,
+      'info',
+      { running: true }
+    );
+
+    if (!page?.url) {
+      job.errorCount += 1;
+      updateJobStatus(job, `Skipping entry with missing URL: ${pageTitle}`, 'error', { running: true });
+      continue;
+    }
+
+    try {
+      const readyTab = await ensureTabAtUrl(job.tabId, page.url, lastVisitedUrl);
+      lastVisitedUrl = readyTab?.url || readyTab?.pendingUrl || page.url;
+
+      if (job.cancelRequested) {
+        break;
+      }
+
+      const convertResponse = await sendAsyncMessageToTab(job.tabId, { action: 'convertToMarkdown' });
+
+      if (convertResponse && convertResponse.success) {
+        const displayTitle = page.title || convertResponse.markdownTitle || `Page ${job.processedCount + 1}`;
+        const preferredFileTitle = page.title && page.title.trim()
+          ? page.title
+          : convertResponse.markdownTitle || convertResponse.currentTitle || displayTitle;
+
+        const fileTitle = ensureUniqueFileTitle(preferredFileTitle, job.processedCount + 1, usedFileTitles);
+
+        job.convertedPages.push({
+          displayTitle,
+          fileTitle,
+          content: convertResponse.markdown,
+          sourceUrl: page.url,
+          attachments: Array.isArray(convertResponse.attachments) ? convertResponse.attachments : []
+        });
+
+        job.processedCount += 1;
+      } else {
+        job.errorCount += 1;
+        updateJobStatus(job, `Failed to process ${pageTitle}. Continuing...`, 'error', { running: true });
+      }
+    } catch (error) {
+      job.errorCount += 1;
+      console.error(`Error processing page: ${pageTitle}`, error);
+      updateJobStatus(job, `Failed to process ${pageTitle}. Continuing...`, 'error', { running: true });
+
+      try {
+        const fallbackTab = await chrome.tabs.get(job.tabId);
+        lastVisitedUrl = fallbackTab.url || fallbackTab.pendingUrl || lastVisitedUrl;
+      } catch (fallbackError) {
+        // Ignore and keep last known URL
+      }
+    }
+  }
+
+  await safelyReturnToUrl(job.tabId, currentPageUrl);
+
+  if (!job.cancelRequested) {
+    updateJobStatus(
+      job,
+      `Batch conversion complete! Success: ${job.processedCount}, Failed: ${job.errorCount}, Preparing download...`,
+      'success',
+      { running: true }
+    );
+  }
+}
+
+async function downloadJobZip(job) {
+  if (job.cancelRequested) {
+    return;
+  }
+
+  updateJobStatus(job, 'Creating ZIP file...', 'info', { running: true });
+
+  const zip = new JSZip();
+  let indexContent = `# ${job.folderName}\n\n## Content Index\n\n`;
+  job.convertedPages.forEach(page => {
+    indexContent += `- [${page.displayTitle}](${page.fileTitle}.md)\n`;
+    if (Array.isArray(page.attachments) && page.attachments.length > 0) {
+      indexContent += `  - Attachments (${page.attachments.length}) stored in attachments/${page.fileTitle}/\n`;
+    }
+  });
+  zip.file('README.md', indexContent);
+
+  let attachmentsRoot = null;
+  job.convertedPages.forEach(page => {
+    zip.file(`${page.fileTitle}.md`, page.content);
+
+    if (!Array.isArray(page.attachments) || page.attachments.length === 0) {
+      return;
+    }
+
+    const usedNames = new Set();
+    if (!attachmentsRoot) {
+      attachmentsRoot = zip.folder('attachments');
+    }
+    const pageAttachmentFolder = attachmentsRoot.folder(page.fileTitle);
+    page.attachments.forEach((attachment, index) => {
+      if (!attachment || typeof attachment.content !== 'string') {
+        return;
+      }
+
+      const rawName = sanitizeFilename(
+        attachment.fileName || attachment.displayName || `attachment-${index + 1}`
+      );
+      const candidateName = ensureMarkdownExtension(rawName || `attachment-${index + 1}`);
+      const uniqueName = ensureUniqueName(candidateName, usedNames);
+
+      pageAttachmentFolder.file(uniqueName, attachment.content);
+    });
+  });
+
+  updateJobStatus(job, 'Compressing files...', 'info', { running: true });
+  const zipContent = await zip.generateAsync({
+    type: 'blob',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 9 }
+  });
+
+  if (job.cancelRequested) {
+    return;
+  }
+
+  const zipUrl = URL.createObjectURL(zipContent);
+
+  await new Promise((resolve, reject) => {
+    chrome.downloads.download(
+      {
+        url: zipUrl,
+        filename: `${sanitizeFilename(job.folderName || 'deepwiki-export')}.zip`,
+        saveAs: true
+      },
+      downloadId => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        resolve(downloadId);
+      }
+    );
+  }).finally(() => {
+    URL.revokeObjectURL(zipUrl);
+  });
 }
 
 // Listen for extension installation event
@@ -51,6 +364,40 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     }
     console.log(`Content script ready on tab ${tabId}. Queue processed.`);
     sendResponse({ status: 'ready' });
+  } else if (request.action === 'startBatchConversion') {
+    const { tabId } = request;
+    if (!tabId) {
+      sendResponse({ success: false, error: 'Missing tab id' });
+      return true;
+    }
+
+    if (batchJobs.has(tabId)) {
+      sendResponse({ success: false, error: 'Batch conversion already running' });
+      return true;
+    }
+
+    const job = createBatchJob(tabId);
+    batchJobs.set(tabId, job);
+    runBatchConversion(job).catch(error => {
+      console.error('Batch conversion failed', error);
+    });
+    sendResponse({ success: true });
+  } else if (request.action === 'cancelBatchConversion') {
+    const { tabId } = request;
+    const job = tabId ? batchJobs.get(tabId) : null;
+
+    if (!job) {
+      sendResponse({ success: false, error: 'No batch conversion in progress' });
+      return true;
+    }
+
+    job.cancelRequested = true;
+    updateJobStatus(job, 'Cancelling batch operation...', 'info', { running: true });
+    sendResponse({ success: true });
+  } else if (request.action === 'getBatchStatus') {
+    const { tabId } = request;
+    const job = tabId ? batchJobs.get(tabId) : null;
+    sendResponse({ success: true, job: job ? serializeJob(job) : null });
   }
   return true;
 });
@@ -96,4 +443,12 @@ chrome.tabs.onRemoved.addListener(tabId => {
     delete messageQueue[tabId];
     console.log(`Cleaned up message queue for closed tab ${tabId}.`);
   }
-}); 
+
+  if (batchJobs.has(tabId)) {
+    const job = batchJobs.get(tabId);
+    job.cancelled = true;
+    job.completed = true;
+    updateJobStatus(job, 'Tab closed. Batch conversion stopped.', 'error', { completed: true, running: false });
+    batchJobs.delete(tabId);
+  }
+});

--- a/popup.html
+++ b/popup.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8">
   <title>DeepWiki to Markdown</title>
   <link rel="stylesheet" href="styles.css">
-  <!-- Use local JSZip library -->
-  <script src="lib/jszip.min.js"></script>
 </head>
 <body>
   <div class="container">

--- a/popup.js
+++ b/popup.js
@@ -1,199 +1,11 @@
+import JSZip from './utils/jszipLoader.js';
+import {
+  sanitizeFilename,
+  ensureMarkdownExtension,
+  ensureUniqueName
+} from './utils/fileNameUtils.js';
+import { sendMessageToTab } from './utils/tabNavigation.js';
 import { isSupportedWikiUrl } from './utils/urlUtils.js';
-
-const FALLBACK_FILENAME = 'deepwiki-page';
-
-function sanitizeFilename(input, options = {}) {
-  const { allowEmpty = false } = options;
-
-  if (!input || typeof input !== 'string') {
-    return allowEmpty ? '' : FALLBACK_FILENAME;
-  }
-
-  let sanitized = input
-    .normalize('NFKC')
-    .trim()
-    .replace(/\s+/g, '-');
-
-  sanitized = sanitized
-    .replace(/[\u0000-\u001F<>:"/\\|?*\u007F]/g, '-')
-    .replace(/\.\.+/g, '.')
-    .replace(/-+/g, '-')
-    .replace(/\.+/g, '.');
-
-  sanitized = sanitized.replace(/^[.-]+/, '').replace(/[.-]+$/, '');
-
-  if (!sanitized) {
-    return allowEmpty ? '' : FALLBACK_FILENAME;
-  }
-
-  return sanitized;
-}
-
-function ensureMarkdownExtension(fileName) {
-  if (!fileName) {
-    return 'resource.md';
-  }
-
-  return fileName.toLowerCase().endsWith('.md') ? fileName : `${fileName}.md`;
-}
-
-function ensureUniqueName(baseName, usedNames) {
-  const normalizedBase = baseName.toLowerCase();
-  if (!usedNames.has(normalizedBase)) {
-    usedNames.add(normalizedBase);
-    return baseName;
-  }
-
-  const baseWithoutExtension = baseName.replace(/\.md$/i, '');
-  let index = 2;
-  let candidate = ensureMarkdownExtension(`${baseWithoutExtension}-${index}`);
-
-  while (usedNames.has(candidate.toLowerCase())) {
-    index += 1;
-    candidate = ensureMarkdownExtension(`${baseWithoutExtension}-${index}`);
-  }
-
-  usedNames.add(candidate.toLowerCase());
-  return candidate;
-}
-
-async function ensureContentScriptInjected(tabId) {
-  try {
-    await chrome.scripting.executeScript({
-      target: { tabId },
-      files: ['content.js']
-    });
-    await delay(100);
-  } catch (error) {
-    if (error?.message?.includes('Cannot access contents of url')) {
-      throw new Error('Cannot access page contents. Please refresh and try again.');
-    }
-    throw error;
-  }
-}
-
-async function sendMessageToTab(tabId, message, options = {}) {
-  const { retryOnMissingReceiver = true } = options;
-
-  try {
-    return await chrome.tabs.sendMessage(tabId, message);
-  } catch (error) {
-    const missingReceiver =
-      error?.message?.includes('Receiving end does not exist') ||
-      error?.message?.includes('The message port closed before a response was received.');
-
-    if (retryOnMissingReceiver && missingReceiver) {
-      await ensureContentScriptInjected(tabId);
-      return chrome.tabs.sendMessage(tabId, message);
-    }
-
-    throw error;
-  }
-}
-
-const PAGE_READY_TIMEOUT_MS = 20000;
-const PAGE_READY_POLL_INTERVAL_MS = 300;
-
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function normalizeUrlForComparison(rawUrl) {
-  if (!rawUrl || typeof rawUrl !== 'string') {
-    return '';
-  }
-
-  try {
-    const url = new URL(rawUrl);
-    let normalizedPath = url.pathname;
-    if (normalizedPath.length > 1) {
-      normalizedPath = normalizedPath.replace(/\/+/g, '/');
-      normalizedPath = normalizedPath.replace(/\/+$/, '');
-    }
-
-    return `${url.origin}${normalizedPath}${url.search}${url.hash}`;
-  } catch (error) {
-    return rawUrl;
-  }
-}
-
-function urlsReferToSameDocument(firstUrl, secondUrl) {
-  return normalizeUrlForComparison(firstUrl) === normalizeUrlForComparison(secondUrl);
-}
-
-function shareSameOrigin(firstUrl, secondUrl) {
-  if (!firstUrl || !secondUrl) {
-    return false;
-  }
-
-  try {
-    const first = new URL(firstUrl);
-    const second = new URL(secondUrl);
-    return first.origin === second.origin;
-  } catch (error) {
-    return false;
-  }
-}
-
-async function waitForPageInteractive(tabId, targetUrl, previousUrl) {
-  const normalizedTarget = normalizeUrlForComparison(targetUrl);
-  const normalizedPrevious = normalizeUrlForComparison(previousUrl);
-  const startTime = Date.now();
-
-  while (Date.now() - startTime < PAGE_READY_TIMEOUT_MS) {
-    let tab;
-    try {
-      tab = await chrome.tabs.get(tabId);
-    } catch (error) {
-      if (error && error.message && error.message.includes('No tab with id')) {
-        throw error;
-      }
-      await delay(PAGE_READY_POLL_INTERVAL_MS);
-      continue;
-    }
-
-    const currentUrl = tab.url || tab.pendingUrl || '';
-    const normalizedCurrent = normalizeUrlForComparison(currentUrl);
-
-    if (normalizedCurrent === normalizedTarget) {
-      try {
-        const response = await sendMessageToTab(tabId, { action: 'ping' });
-        if (response && response.ready) {
-          return tab;
-        }
-      } catch (error) {
-        // Ignore errors while waiting for the content script to initialize
-      }
-    }
-
-    await delay(PAGE_READY_POLL_INTERVAL_MS);
-  }
-
-  throw new Error(`Timed out waiting for page readiness: ${targetUrl}`);
-}
-
-async function ensureTabAtUrl(tabId, targetUrl, previousUrl) {
-  if (!urlsReferToSameDocument(previousUrl, targetUrl)) {
-    await chrome.tabs.update(tabId, { url: targetUrl });
-  }
-
-  return waitForPageInteractive(tabId, targetUrl, previousUrl);
-}
-
-async function safelyReturnToUrl(tabId, targetUrl) {
-  if (!targetUrl) {
-    return null;
-  }
-
-  try {
-    const currentTab = await chrome.tabs.get(tabId);
-    const currentUrl = currentTab.url || currentTab.pendingUrl || '';
-    return await ensureTabAtUrl(tabId, targetUrl, currentUrl);
-  } catch (error) {
-    console.error('Failed to return to original page', error);
-    return null;
-  }
-}
 
 document.addEventListener('DOMContentLoaded', () => {
   const convertBtn = document.getElementById('convertBtn');
@@ -201,18 +13,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const cancelBtn = document.getElementById('cancelBtn');
   const status = document.getElementById('status');
   let currentMarkdown = '';
-  let currentTitle = '';
-  let currentHeadTitle = '';
   let currentAttachments = [];
-  let allPages = [];
-  let convertedPages = []; // Store all converted page content
-  let isCancelled = false; // Flag to control cancellation
+  let currentTabId = null;
+  let activeBatchTabId = null;
+
+  chrome.runtime.onMessage.addListener(message => {
+    if (message?.action === 'batchUpdate') {
+      handleBatchUpdate(message);
+    }
+  });
+
+  initializeTabState();
 
   // Convert button click event - now also downloads
   convertBtn.addEventListener('click', async () => {
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      
+
       if (!isSupportedWikiUrl(tab?.url)) {
         showStatus('Please use this extension on a DeepWiki page', 'error');
         return;
@@ -220,8 +37,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
       currentAttachments = [];
       showStatus('Converting page...', 'info');
-        const response = await sendMessageToTab(tab.id, { action: 'convertToMarkdown' });
-      
+      const response = await sendMessageToTab(tab.id, { action: 'convertToMarkdown' });
+
       if (response && response.success) {
         currentMarkdown = response.markdown;
 
@@ -230,8 +47,6 @@ document.addEventListener('DOMContentLoaded', () => {
           response.markdownTitle || response.currentTitle || ''
         );
 
-        currentTitle = sanitizedContentTitle;
-        currentHeadTitle = sanitizedHeadTitle;
         currentAttachments = Array.isArray(response.attachments) ? response.attachments : [];
 
         const fileNameBase = sanitizedHeadTitle
@@ -304,246 +119,101 @@ document.addEventListener('DOMContentLoaded', () => {
   batchDownloadBtn.addEventListener('click', async () => {
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      
-      if (!isSupportedWikiUrl(tab?.url)) {
-        showStatus('Please use this extension on a DeepWiki page', 'error');
-        return;
-      }
-
-      // Reset cancellation flag and show cancel button
-      isCancelled = false;
-      showCancelButton(true);
-      disableBatchButton(true);
-
-      showStatus('Extracting all page links...', 'info');
-      
-      // Extract all links first
-      const response = await sendMessageToTab(tab.id, { action: 'extractAllPages' });
-      
-      if (response && response.success) {
-        allPages = response.pages;
-        
-        // Use head title for folder name if available
-        const headTitle = sanitizeFilename(response.headTitle, { allowEmpty: true });
-        const fallbackFolderName = sanitizeFilename(response.currentTitle || '');
-        const folderName = headTitle || fallbackFolderName;
-        
-        // Clear previous conversion results
-        convertedPages = [];
-        
-        showStatus(`Found ${allPages.length} pages, starting batch conversion`, 'info');
-        
-        // Process all pages - collect conversion results
-        await processAllPages(tab.id, folderName);
-        
-        // Download all collected content at once if not cancelled
-        if (!isCancelled && convertedPages.length > 0) {
-          await downloadAllPagesAsZip(folderName);
-        }
-      } else {
-        showStatus('Failed to extract page links: ' + (response?.error || 'Unknown error'), 'error');
-      }
+      await startBatchConversion(tab);
     } catch (error) {
       showStatus('An error occurred: ' + error.message, 'error');
-    } finally {
-      // Hide cancel button and re-enable batch button
-      showCancelButton(false);
-      disableBatchButton(false);
     }
   });
 
   // Cancel button click event
-  cancelBtn.addEventListener('click', () => {
-    isCancelled = true;
-    showStatus('Cancelling batch operation...', 'info');
-    showCancelButton(false);
-    disableBatchButton(false);
-  });
-
-  // Process all pages - collect conversion results but don't download immediately
-  async function processAllPages(tabId, folderName) {
-    let processedCount = 0;
-    let errorCount = 0;
-    const usedFileTitles = new Set();
-
-    const ensureUniqueFileTitle = (baseTitle, index) => {
-      let candidate = sanitizeFilename(baseTitle || `page-${index}`);
-      if (!candidate) {
-        candidate = `page-${index}`;
-      }
-
-      if (!usedFileTitles.has(candidate)) {
-        usedFileTitles.add(candidate);
-        return candidate;
-      }
-
-      let suffix = 2;
-      let uniqueCandidate = `${candidate}-${suffix}`;
-      while (usedFileTitles.has(uniqueCandidate)) {
-        suffix += 1;
-        uniqueCandidate = `${candidate}-${suffix}`;
-      }
-
-      usedFileTitles.add(uniqueCandidate);
-      return uniqueCandidate;
-    };
-
-    // Save current page URL
-    const currentPageUrl = allPages.find(page => page.selected)?.url || "";
-    let lastVisitedUrl = currentPageUrl;
-
-    try {
-      const activeTab = await chrome.tabs.get(tabId);
-      lastVisitedUrl = activeTab.url || activeTab.pendingUrl || currentPageUrl;
-    } catch (error) {
-      lastVisitedUrl = currentPageUrl;
+  cancelBtn.addEventListener('click', async () => {
+    if (!activeBatchTabId) {
+      showCancelButton(false);
+      disableBatchButton(false);
+      return;
     }
 
-    for (const page of allPages) {
-      // Check if operation was cancelled
-      if (isCancelled) {
-        showStatus(`Operation cancelled. Processed: ${processedCount}, Failed: ${errorCount}`, 'info');
-        // Return to original page
-        await safelyReturnToUrl(tabId, currentPageUrl);
+    showStatus('Cancelling batch operation...', 'info');
+    try {
+      await chrome.runtime.sendMessage({ action: 'cancelBatchConversion', tabId: activeBatchTabId });
+    } catch (error) {
+      showStatus('Failed to cancel batch operation: ' + error.message, 'error');
+    }
+  });
+
+  async function initializeTabState() {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      currentTabId = tab?.id ?? null;
+
+      if (!currentTabId) {
+        resetBatchUiState();
         return;
       }
 
-      try {
-        showStatus(`Processing ${processedCount + 1}/${allPages.length}: ${page.title}`, 'info');
-
-        // Ensure the tab has navigated and the content script is ready
-        const readyTab = await ensureTabAtUrl(tabId, page.url, lastVisitedUrl);
-        lastVisitedUrl = readyTab?.url || readyTab?.pendingUrl || page.url;
-
-        // Check again if cancelled after navigation
-        if (isCancelled) {
-          showStatus(`Operation cancelled. Processed: ${processedCount}, Failed: ${errorCount}`, 'info');
-          await safelyReturnToUrl(tabId, currentPageUrl);
-          return;
-        }
-
-        // Convert page content
-        const convertResponse = await sendMessageToTab(tabId, { action: 'convertToMarkdown' });
-        
-        if (convertResponse && convertResponse.success) {
-          const displayTitle = page.title || convertResponse.markdownTitle || `Page ${processedCount + 1}`;
-          const preferredFileTitle =
-            page.title && page.title.trim()
-              ? page.title
-              : convertResponse.markdownTitle || convertResponse.currentTitle || displayTitle;
-
-          const fileTitle = ensureUniqueFileTitle(preferredFileTitle, processedCount + 1);
-
-          // Store converted content
-          convertedPages.push({
-            displayTitle,
-            fileTitle,
-            content: convertResponse.markdown,
-            sourceUrl: page.url,
-            attachments: Array.isArray(convertResponse.attachments) ? convertResponse.attachments : []
-          });
-
-          processedCount++;
-        } else {
-          errorCount++;
-          console.error(`Page processing failed: ${page.title}`, convertResponse?.error);
-        }
-      } catch (err) {
-        errorCount++;
-        console.error(`Error processing page: ${page.title}`, err);
-        showStatus(`Failed to process ${page.title}. Continuing...`, 'error');
-
-        try {
-          const fallbackTab = await chrome.tabs.get(tabId);
-          lastVisitedUrl = fallbackTab.url || fallbackTab.pendingUrl || lastVisitedUrl;
-        } catch (fallbackError) {
-          // Ignore - we'll rely on the last known URL
-        }
+      const response = await chrome.runtime.sendMessage({ action: 'getBatchStatus', tabId: currentTabId });
+      if (response?.job) {
+        handleBatchUpdate({ tabId: currentTabId, ...response.job });
+      } else {
+        resetBatchUiState();
       }
-    }
-
-    // Return to original page after processing
-    await safelyReturnToUrl(tabId, currentPageUrl);
-
-    if (!isCancelled) {
-      showStatus(`Batch conversion complete! Success: ${processedCount}, Failed: ${errorCount}, Preparing download...`, 'success');
+    } catch (error) {
+      console.error('Failed to initialize tab state', error);
+      resetBatchUiState();
     }
   }
-  
-  // Package all pages into a ZIP file for download
-  async function downloadAllPagesAsZip(folderName) {
-    try {
-      showStatus('Creating ZIP file...', 'info');
-      
-      // Create new JSZip instance
-      const zip = new JSZip();
-      
-      // Create index file
-      let indexContent = `# ${folderName}\n\n## Content Index\n\n`;
-      convertedPages.forEach(page => {
-        indexContent += `- [${page.displayTitle}](${page.fileTitle}.md)\n`;
-        if (Array.isArray(page.attachments) && page.attachments.length > 0) {
-          indexContent += `  - Attachments (${page.attachments.length}) stored in attachments/${page.fileTitle}/\n`;
-        }
-      });
 
-      // Add index file to zip
-      zip.file('README.md', indexContent);
-
-      // Add all Markdown files to zip
-      let attachmentsRoot = null;
-      convertedPages.forEach(page => {
-        zip.file(`${page.fileTitle}.md`, page.content);
-
-        if (!Array.isArray(page.attachments) || page.attachments.length === 0) {
-          return;
-        }
-
-        const usedNames = new Set();
-        if (!attachmentsRoot) {
-          attachmentsRoot = zip.folder('attachments');
-        }
-        const pageAttachmentFolder = attachmentsRoot.folder(page.fileTitle);
-        page.attachments.forEach((attachment, index) => {
-          if (!attachment || typeof attachment.content !== 'string') {
-            return;
-          }
-
-          const rawName = sanitizeFilename(
-            attachment.fileName || attachment.displayName || `attachment-${index + 1}`
-          );
-          const candidateName = ensureMarkdownExtension(rawName || `attachment-${index + 1}`);
-          const uniqueName = ensureUniqueName(candidateName, usedNames);
-
-          pageAttachmentFolder.file(uniqueName, attachment.content);
-        });
-      });
-      
-      // Generate zip file
-      showStatus('Compressing files...', 'info');
-      const zipContent = await zip.generateAsync({
-        type: 'blob',
-        compression: 'DEFLATE',
-        compressionOptions: { level: 9 }
-      });
-      
-      // Download zip file
-      const zipUrl = URL.createObjectURL(zipContent);
-      chrome.downloads.download({
-        url: zipUrl,
-        filename: `${sanitizeFilename(folderName)}.zip`,
-        saveAs: true
-      }, () => {
-        if (chrome.runtime.lastError) {
-          showStatus('Error downloading ZIP file: ' + chrome.runtime.lastError.message, 'error');
-        } else {
-          showStatus(`ZIP file successfully generated! Contains ${convertedPages.length} Markdown files`, 'success');
-        }
-      });
-      
-    } catch (error) {
-      showStatus('Error creating ZIP file: ' + error.message, 'error');
+  async function startBatchConversion(tab) {
+    if (!tab?.id) {
+      showStatus('Unable to determine active tab', 'error');
+      return;
     }
+
+    if (!isSupportedWikiUrl(tab?.url)) {
+      showStatus('Please use this extension on a DeepWiki page', 'error');
+      return;
+    }
+
+    showCancelButton(true);
+    disableBatchButton(true);
+    showStatus('Preparing batch conversion...', 'info');
+
+    try {
+      const response = await chrome.runtime.sendMessage({ action: 'startBatchConversion', tabId: tab.id });
+      if (!response?.success) {
+        throw new Error(response?.error || 'Failed to start batch conversion');
+      }
+      activeBatchTabId = tab.id;
+    } catch (error) {
+      showStatus('Failed to start batch conversion: ' + error.message, 'error');
+      showCancelButton(false);
+      disableBatchButton(false);
+    }
+  }
+
+  function handleBatchUpdate(update) {
+    if (!currentTabId || update.tabId !== currentTabId) {
+      return;
+    }
+
+    if (typeof update.message === 'string') {
+      showStatus(update.message, update.statusType || 'info');
+    }
+
+    const isRunning = Boolean(update.running);
+    showCancelButton(isRunning);
+    disableBatchButton(isRunning);
+
+    if (update.completed || update.cancelled || !isRunning) {
+      activeBatchTabId = null;
+    } else {
+      activeBatchTabId = update.tabId;
+    }
+  }
+
+  function resetBatchUiState() {
+    showCancelButton(false);
+    disableBatchButton(false);
   }
 
   // Show or hide cancel button
@@ -561,4 +231,4 @@ document.addEventListener('DOMContentLoaded', () => {
     status.textContent = message;
     status.className = type;
   }
-}); 
+});

--- a/utils/fileNameUtils.js
+++ b/utils/fileNameUtils.js
@@ -1,0 +1,88 @@
+export const FALLBACK_FILENAME = 'deepwiki-page';
+
+export function sanitizeFilename(input, options = {}) {
+  const { allowEmpty = false } = options;
+
+  if (!input || typeof input !== 'string') {
+    return allowEmpty ? '' : FALLBACK_FILENAME;
+  }
+
+  let sanitized = input
+    .normalize('NFKC')
+    .trim()
+    .replace(/\s+/g, '-');
+
+  sanitized = sanitized
+    .replace(/[\u0000-\u001F<>:"/\\|?*\u007F]/g, '-')
+    .replace(/\.\.+/g, '.')
+    .replace(/-+/g, '-')
+    .replace(/\.+/g, '.');
+
+  sanitized = sanitized.replace(/^[.-]+/, '').replace(/[.-]+$/, '');
+
+  if (!sanitized) {
+    return allowEmpty ? '' : FALLBACK_FILENAME;
+  }
+
+  return sanitized;
+}
+
+export function ensureMarkdownExtension(fileName) {
+  if (!fileName) {
+    return 'resource.md';
+  }
+
+  return fileName.toLowerCase().endsWith('.md') ? fileName : `${fileName}.md`;
+}
+
+export function ensureUniqueName(baseName, usedNames) {
+  if (!(usedNames instanceof Set)) {
+    return baseName;
+  }
+
+  const normalizedBase = baseName.toLowerCase();
+  if (!usedNames.has(normalizedBase)) {
+    usedNames.add(normalizedBase);
+    return baseName;
+  }
+
+  const baseWithoutExtension = baseName.replace(/\.md$/i, '');
+  let index = 2;
+  let candidate = ensureMarkdownExtension(`${baseWithoutExtension}-${index}`);
+
+  while (usedNames.has(candidate.toLowerCase())) {
+    index += 1;
+    candidate = ensureMarkdownExtension(`${baseWithoutExtension}-${index}`);
+  }
+
+  usedNames.add(candidate.toLowerCase());
+  return candidate;
+}
+
+export function ensureUniqueFileTitle(baseTitle, index, usedTitles) {
+  const fallback = `page-${index}`;
+  let candidate = sanitizeFilename(baseTitle || fallback, { allowEmpty: true });
+
+  if (!candidate) {
+    candidate = fallback;
+  }
+
+  if (!(usedTitles instanceof Set)) {
+    return candidate;
+  }
+
+  if (!usedTitles.has(candidate)) {
+    usedTitles.add(candidate);
+    return candidate;
+  }
+
+  let suffix = 2;
+  let uniqueCandidate = `${candidate}-${suffix}`;
+  while (usedTitles.has(uniqueCandidate)) {
+    suffix += 1;
+    uniqueCandidate = `${candidate}-${suffix}`;
+  }
+
+  usedTitles.add(uniqueCandidate);
+  return uniqueCandidate;
+}

--- a/utils/jszipLoader.js
+++ b/utils/jszipLoader.js
@@ -1,0 +1,9 @@
+import '../lib/jszip.min.js';
+
+const { JSZip } = globalThis;
+
+if (!JSZip) {
+  throw new Error('Failed to load JSZip library');
+}
+
+export default JSZip;

--- a/utils/tabNavigation.js
+++ b/utils/tabNavigation.js
@@ -1,0 +1,122 @@
+const PAGE_READY_TIMEOUT_MS = 20000;
+const PAGE_READY_POLL_INTERVAL_MS = 300;
+
+export function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function ensureContentScriptInjected(tabId) {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ['content.js']
+    });
+    await delay(100);
+  } catch (error) {
+    if (error?.message?.includes('Cannot access contents of url')) {
+      throw new Error('Cannot access page contents. Please refresh and try again.');
+    }
+    throw error;
+  }
+}
+
+export async function sendMessageToTab(tabId, message, options = {}) {
+  const { retryOnMissingReceiver = true } = options;
+
+  try {
+    return await chrome.tabs.sendMessage(tabId, message);
+  } catch (error) {
+    const missingReceiver =
+      error?.message?.includes('Receiving end does not exist') ||
+      error?.message?.includes('The message port closed before a response was received.');
+
+    if (retryOnMissingReceiver && missingReceiver) {
+      await ensureContentScriptInjected(tabId);
+      return chrome.tabs.sendMessage(tabId, message);
+    }
+
+    throw error;
+  }
+}
+
+export function normalizeUrlForComparison(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') {
+    return '';
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    let normalizedPath = url.pathname;
+    if (normalizedPath.length > 1) {
+      normalizedPath = normalizedPath.replace(/\\+/g, '/');
+      normalizedPath = normalizedPath.replace(/\/+$/, '');
+    }
+
+    return `${url.origin}${normalizedPath}${url.search}${url.hash}`;
+  } catch (error) {
+    return rawUrl;
+  }
+}
+
+export function urlsReferToSameDocument(firstUrl, secondUrl) {
+  return normalizeUrlForComparison(firstUrl) === normalizeUrlForComparison(secondUrl);
+}
+
+export async function waitForPageInteractive(tabId, targetUrl) {
+  const normalizedTarget = normalizeUrlForComparison(targetUrl);
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < PAGE_READY_TIMEOUT_MS) {
+    let tab;
+    try {
+      tab = await chrome.tabs.get(tabId);
+    } catch (error) {
+      if (error && error.message && error.message.includes('No tab with id')) {
+        throw error;
+      }
+      await delay(PAGE_READY_POLL_INTERVAL_MS);
+      continue;
+    }
+
+    const currentUrl = tab.url || tab.pendingUrl || '';
+    const normalizedCurrent = normalizeUrlForComparison(currentUrl);
+
+    if (normalizedCurrent === normalizedTarget) {
+      try {
+        const response = await sendMessageToTab(tabId, { action: 'ping' });
+        if (response && response.ready) {
+          return tab;
+        }
+      } catch (error) {
+        // Ignore errors while waiting for the content script to initialize
+      }
+    }
+
+    await delay(PAGE_READY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timed out waiting for page readiness: ${targetUrl}`);
+}
+
+export async function ensureTabAtUrl(tabId, targetUrl, previousUrl) {
+  if (!urlsReferToSameDocument(previousUrl, targetUrl)) {
+    await chrome.tabs.update(tabId, { url: targetUrl });
+  }
+
+  return waitForPageInteractive(tabId, targetUrl);
+}
+
+export async function safelyReturnToUrl(tabId, targetUrl) {
+  if (!targetUrl) {
+    return null;
+  }
+
+  try {
+    const currentTab = await chrome.tabs.get(tabId);
+    const currentUrl = currentTab.url || currentTab.pendingUrl || '';
+    return await ensureTabAtUrl(tabId, targetUrl, currentUrl);
+  } catch (error) {
+    console.error('Failed to return to original page', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- move shared filename sanitation, tab navigation helpers, and JSZip loading into reusable utility modules
- update the popup to use the new helpers, download single pages as before, and delegate batch conversions to the background worker with live status updates
- implement the batch processor inside the background service worker so it can navigate tabs, convert every page, bundle the results into a ZIP, and honor cancellation requests

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69155f580900832492804c98a3ed49e4)