### PR TITLE
Improve mermaid diagram detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -1879,7 +1879,10 @@ function processNode(node) {
         break;
       }
       case "PRE": {
-        const svgElement = element.querySelector('svg[id^="mermaid-"]');
+        const svgElement =
+          element.querySelector('svg[id^="mermaid-"]') ||
+          element.querySelector('svg[aria-roledescription]') ||
+          element.querySelector('svg[class*="mermaid"]');
         const mermaidOutput = convertMermaidSvgElement(svgElement);
 
         if (mermaidOutput) {


### PR DESCRIPTION
## Summary
- expand the PRE-element mermaid SVG detection so diagrams without the `mermaid-` id prefix are still exported as Mermaid code blocks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915702a567483248c0e78f08c88ce48)